### PR TITLE
Handle death screen detection

### DIFF
--- a/train_rl.py
+++ b/train_rl.py
@@ -6,7 +6,7 @@ p = argparse.ArgumentParser()
 p.add_argument('--steps', type=int, default=1000000)
 a = p.parse_args()
 
-env = UltraKillWrapper()
+env = UltraKillWrapper(mouse=True)
 
 dev = 'cuda' if torch.cuda.is_available() else 'cpu'
 model = PPO('CnnPolicy', env, device=dev, verbose=1, tensorboard_log='runs')


### PR DESCRIPTION
## Summary
- extend state tracking with `prev_dead`
- detect dark death screen and automatically press R
- apply a large penalty when death detected
- allow moving the mouse and clicking LMB/RMB

## Testing
- `python -m py_compile env_ultra.py train_rl.py play_bc.py train_bc.py`

------
https://chatgpt.com/codex/tasks/task_e_68492db2d724832fb58e6dc655688837