### PR TITLE
Fix syntax errors in env_ultra

### DIFF
--- a/env_ultra.py
+++ b/env_ultra.py
@@ -33,17 +33,6 @@ RAIL_TL, RAIL_BR = (80, 725),  (276, 755)
 STYLE_TEXT_TL, STYLE_TEXT_BR = (780, 155), (950, 210)
 STYLE_BAR_TL,  STYLE_BAR_BR  = (780, 230), (1020, 265)
 
-# Style rank colors in RGB space
-STYLE_COLORS = {
-    "DESTRUCTIVE": (0, 110, 255),
-    "CHAOTIC": (50, 255, 50),
-    "BRUTAL": (255, 235, 30),
-    "ANARCHIC": (255, 140, 30),
-    "SUPREME": (220, 0, 0),
-    "SSADISTIC": (220, 0, 0),
-    "SSSHITSTORM": (220, 0, 0),
-    "ULTRAKILL": (255, 220, 70),
-
 # Approximate BGR colors for style ranks
 STYLE_COLORS = {
     "DESTRUCTIVE": (255, 110, 0),
@@ -125,10 +114,7 @@ class UltraKillEnv:
         self._ensure_process()
         self._ensure_window()
         self._check_exit()
-        scr = np.asarray(self.sct.grab(self.win_bbox))[:, :, :3]
-        scr = cv2.cvtColor(scr, cv2.COLOR_BGR2RGB)
         scr = np.asarray(self.sct.grab(self.win_bbox))[:, :, :3]  # BGR
-        scr = np.asarray(self.sct.grab(self.mon))[:,:,:3]         # BGR
         return cv2.resize(scr, self.res, interpolation=cv2.INTER_AREA)
 
     def _ensure_process(self):
@@ -231,9 +217,6 @@ class UltraKillEnv:
         obs   = frame.transpose(2,0,1)
         w, h  = self.res
         x1, y1, x2, y2 = self._scale_coords(HP_TL, HP_BR)
-        hp = frame[y1:y2, x1:x2, 0].mean() / 255
-        x1, y1, x2, y2 = self._scale_coords(STAM_TL, STAM_BR)
-        dash = frame[y1:y2, x1:x2, 2].mean() / 255
         hp = frame[y1:y2, x1:x2, 2].mean() / 255
         x1, y1, x2, y2 = self._scale_coords(STAM_TL, STAM_BR)
         dash = frame[y1:y2, x1:x2, 0].mean() / 255


### PR DESCRIPTION
## Summary
- remove stray duplicate STYLE_COLORS dict
- clean up screenshot grabbing code
- remove duplicated HP/dash extraction logic

## Testing
- `python -m py_compile build_dataset_stream.py capture_inputs.py check.py check_cuda.py checkkey.py env_ultra.py fix_json.py play_bc.py play_bot.py shift_log.py train_bc.py train_rl.py`
- `python train_rl.py --steps 10` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*

------
https://chatgpt.com/codex/tasks/task_e_6849ee96ced8832f9b7a14accb69b7e0