### PR TITLE
Fix RL reward exploits

### DIFF
--- a/env_ultra.py
+++ b/env_ultra.py
@@ -250,6 +250,7 @@ class UltraKillEnv:
 
         # --- reward ---
         r = 0.0
+        terminated = False
 
         # exploration based on frame difference
         if self.prev_frame is not None:
@@ -257,7 +258,7 @@ class UltraKillEnv:
             if diff < 1.0:
                 self.stuck_frames += 1
                 if self.stuck_frames > 180:
-                    r -= 0.2                     # penalty for staying still
+                    r -= 1.0                     # stronger penalty for staying still
             else:
                 r += diff / 50.0                # encourage movement
                 if diff > 20.0:
@@ -288,10 +289,12 @@ class UltraKillEnv:
         if hp_loss > 0:
             r -= hp_loss * 5.0                      # сильное наказание за урон
         if hp < 0.1 and self.prev_hp >= 0.1:
-            r -= 20.0                               # смерть
+            r -= 50.0                               # смерть
+            terminated = True
         if dead and not self.prev_dead:
             pydirectinput.press('r')
-            r -= 30.0                               # чётко умер
+            r -= 50.0                               # чётко умер
+            terminated = True
 
         style_gain = style - self.prev_style
         if style_gain > 0:
@@ -312,7 +315,7 @@ class UltraKillEnv:
             self.prev_style_rank = style_rank
 
         if self.frames_since_style > 30 and (action[7] or action[8]):
-            r -= 0.1                                # стрельба без врагов
+            r -= 0.5                                # стрельба без врагов
 
         r += (rail - self.prev_rail) * 2.0          # заряд rail
 
@@ -372,7 +375,7 @@ class UltraKillEnv:
         self.prev_dead = dead
         self.prev_frame = frame
 
-        return obs, r, False, False, {}    # (no terminal flag yet)
+        return obs, r, terminated, False, {}    # terminated when dead
 
     def render(self, *a, **kw):
         pass

--- a/play_bot.py
+++ b/play_bot.py
@@ -8,6 +8,7 @@ model=PPO.load(a.weights,env=env,device='cuda' if torch.cuda.is_available() else
 obs,_=env.reset()
 while True:
     action,_=model.predict(obs,deterministic=True)
-    obs,_,done,_,_=env.step(action)
-    if done: obs,_=env.reset()
+    obs,_,terminated,_,_=env.step(action)
+    if terminated:
+        obs,_=env.reset()
     time.sleep(0.016)


### PR DESCRIPTION
## Summary
- harden reward penalties in `env_ultra.py`
- exit episodes when dying in the environment
- reload after termination in `play_bot.py`

## Testing
- `python -m py_compile env_ultra.py play_bot.py train_rl.py`
- `python check_cuda.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849f22f9234832faa10294c4c0288ee