### PR TITLE
Fix RL reward exploits

### DIFF
--- a/play_bot.py
+++ b/play_bot.py
@@ -8,6 +8,7 @@ model=PPO.load(a.weights,env=env,device='cuda' if torch.cuda.is_available() else
 obs,_=env.reset()
 while True:
     action,_=model.predict(obs,deterministic=True)
-    obs,_,done,_,_=env.step(action)
-    if done: obs,_=env.reset()
+    obs,_,terminated,_,_=env.step(action)
+    if terminated:
+        obs,_=env.reset()
     time.sleep(0.016)


### PR DESCRIPTION
## Summary
- harden reward penalties in `env_ultra.py`
- exit episodes when dying in the environment
- reload after termination in `play_bot.py`
- introduce escalating penalty for blind firing

## Testing
- `python -m py_compile env_ultra.py play_bot.py train_rl.py`
- `python check_cuda.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849f22f9234832faa10294c4c0288ee