### PR TITLE
Set pydirectinput pause to zero

### DIFF
--- a/env_ultra.py
+++ b/env_ultra.py
@@ -5,6 +5,11 @@ except ImportError:
 
 from gym import spaces
 import numpy as np, cv2, mss, time, pydirectinput
+pydirectinput.PAUSE = 0  # eliminate delays between key events
+try:
+    pydirectinput.MINIMUM_DURATION = 0
+except AttributeError:
+    pass
 import psutil
 import pygetwindow as gw
 from pynput import keyboard


### PR DESCRIPTION
## Summary
- set `pydirectinput.PAUSE` and `MINIMUM_DURATION` to zero
- explain the change with a short comment

## Testing
- `python -m py_compile env_ultra.py`

------
https://chatgpt.com/codex/tasks/task_e_684a28433248832f8d0ac371fadcc5c3